### PR TITLE
updating top level structure of smidje to isolate parser and generator

### DIFF
--- a/doc/data-model.md
+++ b/doc/data-model.md
@@ -1,0 +1,39 @@
+# Data-Model
+
+smidje uses a two step process to generate tests from the provided midje syntax. It will first convert the test syntax 
+into a clojure map with all of the relevant test information. The map is then passed to a generator which will use it 
+to build out a cljs compatible test. Currently the only supported generator is the cljs-test generator which converts
+the map into cljs-test syntax.
+
+```clojure
+{:name-space ""
+ :tests [{
+            :name ""
+            :assertions [{
+                            :function-under-test ""
+                            :call-form ""
+                            :position ""
+                            :expected-result-form ""
+                            :expected-result ""
+                            :arrow ""
+                            :provided [{:mock-function ()
+                                        :return {'(<params>) {:result [...] ;list of results to support =stream=>
+                                                              :calls ""
+                                                              :arrow ""}}}]}]}]}
+``` 
+`:namespace`- The namespace of the fact.  
+`:tests`- A vector of facts (this will be used for nesting which is not supported yet).  
+`:name`- The name of a single fact.  
+`:assertions`- A vector of assertions which are individual arrow statements for example `(+ 1 1) => 2`  
+`:function-under-test`- Quoted form of the function under test (the left side of the arrow)  
+`call-form`- The unquoted function under test  
+`:position`- The line number of the arrow statement  
+`:expected-result-form`- Quoted form of the expected result (right hand side of the arrow)  
+`:expected-result`- Evaluated result of the expected value  
+`:arrow`- The arrow that is being used (=>, =not=>, etc)  
+`:provided`- A vector of maps representing mocks  
+`:mock-function`- The function to mock  
+`:return`- a map of parameters that will be passed to :mock-function and the corresponding value to be returned  
+`:result`- a vector of result values to return (in preparation for the =stream=> arrow)  
+`:calls`- the expected number of calls to this mock  
+`:arrow`- The arrow used for mock creation (=>, =throws=>, etc.)                                                                                                                                                                                                                   

--- a/doc/data-model.md
+++ b/doc/data-model.md
@@ -26,7 +26,7 @@ the map into cljs-test syntax.
 `:name`- The name of a single fact.  
 `:assertions`- A vector of assertions which are individual arrow statements for example `(+ 1 1) => 2`  
 `:function-under-test`- Quoted form of the function under test (the left side of the arrow)  
-`call-form`- The unquoted function under test  
+`:call-form`- The unquoted function under test  
 `:position`- The line number of the arrow statement  
 `:expected-result-form`- Quoted form of the expected result (right hand side of the arrow)  
 `:expected-result`- Evaluated result of the expected value  

--- a/doc/data-model.md
+++ b/doc/data-model.md
@@ -21,7 +21,7 @@ the map into cljs-test syntax.
                                                               :calls ""
                                                               :arrow ""}}}]}]}]}
 ``` 
-`:namespace`- The namespace of the fact.  
+`:name-space`- The namespace of the fact.  
 `:tests`- A vector of facts (this will be used for nesting which is not supported yet).  
 `:name`- The name of a single fact.  
 `:assertions`- A vector of assertions which are individual arrow statements for example `(+ 1 1) => 2`  

--- a/doc/data-model.md
+++ b/doc/data-model.md
@@ -6,7 +6,7 @@ to build out a cljs compatible test. Currently the only supported generator is t
 the map into cljs-test syntax.
 
 ```clojure
-{:name-space ""
+{:namespace ""
  :tests [{
             :name ""
             :assertions [{
@@ -21,7 +21,7 @@ the map into cljs-test syntax.
                                                               :calls ""
                                                               :arrow ""}}}]}]}]}
 ``` 
-`:name-space`- The namespace of the fact.  
+`:namespace`- The namespace of the fact.  
 `:tests`- A vector of facts (this will be used for nesting which is not supported yet).  
 `:name`- The name of a single fact.  
 `:assertions`- A vector of assertions which are individual arrow statements for example `(+ 1 1) => 2`  

--- a/src/smidje/cljs_generator/test_builder.clj
+++ b/src/smidje/cljs_generator/test_builder.clj
@@ -1,5 +1,5 @@
 (ns smidje.cljs-generator.test-builder
-    (:require [smidje.arrows :refer [arrow-set]]
+    (:require [smidje.parser.arrows :refer [arrow-set]]
               [smidje.cljs-generator.mocks :refer [generate-mock-function]]))
 
 (defmulti generate-right-hand

--- a/src/smidje/core.clj
+++ b/src/smidje/core.clj
@@ -1,2 +1,7 @@
-(ns smidje.core)
+(ns smidje.core
+  (:require [smidje.cljs-generator.test-builder :as cljs-builder]
+            [smidje.parser.parser :as parser]))
 
+(defmacro fact [& args]
+  (-> (parser/parse-fact &form)
+      cljs-builder/generate-tests))

--- a/src/smidje/parser/arrows.clj
+++ b/src/smidje/parser/arrows.clj
@@ -1,4 +1,4 @@
-(ns smidje.arrows)
+(ns smidje.parser.arrows)
 
 (def => "=>")
 

--- a/src/smidje/parser/parser.clj
+++ b/src/smidje/parser/parser.clj
@@ -1,6 +1,5 @@
-(ns smidje.parser
-  (:require [smidje.arrows :refer [arrow-set]]
-            [smidje.cljs-generator.test-builder :as cljsbuilder]))
+(ns smidje.parser.parser
+  (:require [smidje.parser.arrows :refer [arrow-set]]))
 
 (declare generate)
 
@@ -131,18 +130,14 @@
       (recur (conj result (parse-equals input)) (drop (if (has-provided-form? input) 4 3 ) input))
       result)))
 
-(defmacro fact
-  [& _]
-  (let [name (if (string? (second &form))
-               (clojure.string/replace (second &form) #"[^\w\d]+" "-")
-               (second &form))
-        fact-forms (drop 2 &form)]
+(defn parse-fact
+  [form]
+  (let [name (if (string? (second form))
+               (clojure.string/replace (second form) #"[^\w\d]+" "-")
+               (second form))
+        fact-forms (drop 2 form)]
     (-> {:tests [{:name name
-         :assertions (parse fact-forms)}]}
-        (generate))))
-
-(defn generate [testmap]
-  (cljsbuilder/generate-tests testmap))
+         :assertions (parse fact-forms)}]})))
 
 (comment
   (macroexpand

--- a/test/smidje/clj/cljs_generator/test_builder_test.clj
+++ b/test/smidje/clj/cljs_generator/test_builder_test.clj
@@ -1,6 +1,6 @@
-(ns smidje.cljs-generator.test-builder-test
+(ns smidje.clj.cljs-generator.test-builder-test
   (:require [midje.sweet :refer :all]
-            [smidje.intermediate-maps :as im]
+            [smidje.clj.parser.intermediate-maps :as im]
             [smidje.cljs-generator.test-builder :refer :all]))
 
 (fact "a single expect match arrow fact"

--- a/test/smidje/clj/parser/intermediate_maps.clj
+++ b/test/smidje/clj/parser/intermediate_maps.clj
@@ -1,4 +1,4 @@
-(ns smidje.intermediate-maps)
+(ns smidje.clj.parser.intermediate-maps)
 
 (def test-metadata
   {:smidje/namespace 'smidje.core-test

--- a/test/smidje/clj/parser/parser_test.clj
+++ b/test/smidje/clj/parser/parser_test.clj
@@ -1,10 +1,10 @@
-(ns smidje.parser-test
+(ns smidje.clj.parser.parser-test
   (:require [midje.sweet :as m]
-            [smidje.intermediate-maps :as im]
-            [smidje.parser :as parser :refer :all])
+            [smidje.clj.parser.intermediate-maps :as im]
+            [smidje.parser.parser :as parser :refer :all])
   (:use     [midje.util :only [expose-testables]]))
 
-(expose-testables smidje.parser)
+(expose-testables smidje.parser.parser)
 
 ; parse is called from fact function, after it pops off the name.
 ; given the fact, call parse with it and get the map
@@ -27,45 +27,45 @@
   (throws-form? 2) => false)
 
 (m/fact "provided-form?"
-        (#'smidje.parser/provided-form? ()) => false
-        (#'smidje.parser/provided-form? "NOTAPROVIDEDFORM") => false
-        (#'smidje.parser/provided-form? '(stillnota provided form)) => false
-        (#'smidje.parser/provided-form? '(:provided form not)) => false
-        (#'smidje.parser/provided-form? '(provided form)) => true)
+        (#'smidje.parser.parser/provided-form? ()) => false
+        (#'smidje.parser.parser/provided-form? "NOTAPROVIDEDFORM") => false
+        (#'smidje.parser.parser/provided-form? '(stillnota provided form)) => false
+        (#'smidje.parser.parser/provided-form? '(:provided form not)) => false
+        (#'smidje.parser.parser/provided-form? '(provided form)) => true)
 
 (m/fact "has-provided-form?"
-        (#'smidje.parser/has-provided-form? simple-addition-fact) => false
-        (#'smidje.parser/has-provided-form? '((+ 1 1) => 2 (* 1 1) => 1)) => false
-        (#'smidje.parser/has-provided-form? '((+ 1 1) => 2 provided (* 1 1) => 1)) => false
-        (#'smidje.parser/has-provided-form? '((+ 1 1) => 2 (provided (* 1 1) => 1) (- 3 1 ) => 2)) => true)
+        (#'smidje.parser.parser/has-provided-form? simple-addition-fact) => false
+        (#'smidje.parser.parser/has-provided-form? '((+ 1 1) => 2 (* 1 1) => 1)) => false
+        (#'smidje.parser.parser/has-provided-form? '((+ 1 1) => 2 provided (* 1 1) => 1)) => false
+        (#'smidje.parser.parser/has-provided-form? '((+ 1 1) => 2 (provided (* 1 1) => 1) (- 3 1 ) => 2)) => true)
 
 (m/fact "gen-provided-sym generates metaconst"
- (#'smidje.parser/gen-provided-sym 'fn1 'fn2)  =>  '..fn1->fn2001.. (m/provided (gensym "fn1->fn2")  m/=> 'fn1->fn2001))
+ (#'smidje.parser.parser/gen-provided-sym 'fn1 'fn2)  =>  '..fn1->fn2001.. (m/provided (gensym "fn1->fn2")  m/=> 'fn1->fn2001))
 
 
 (m/fact "unnest-provided"
-        (#'smidje.parser/unnest-provided simple-addition-fact) => [simple-addition-fact]
-        (set  (#'smidje.parser/unnest-provided '((a 1 (b 2)) => 3))) =>  #{'((a 1 ..a->b01..) => 3) '((b 2) => ..a->b01..)}
+        (#'smidje.parser.parser/unnest-provided simple-addition-fact) => [simple-addition-fact]
+        (set  (#'smidje.parser.parser/unnest-provided '((a 1 (b 2)) => 3))) =>  #{'((a 1 ..a->b01..) => 3) '((b 2) => ..a->b01..)}
             (m/provided (gensym "a->b") m/=> 'a->b01)
-            (set  (#'smidje.parser/unnest-provided '((a 1 (b (c 4)  2)) => 3))) =>
+            (set  (#'smidje.parser.parser/unnest-provided '((a 1 (b (c 4)  2)) => 3))) =>
               #{'((a 1 ..a->b01..) => 3)
                 '((b ..b->c02.. 2) => ..a->b01..)
                 '((c 4) => ..b->c02..)}
             (m/provided (gensym "a->b") m/=> 'a->b01 (gensym "b->c") m/=> 'b->c02))
 
 (m/fact "seperate-provided-forms"
-        (#'smidje.parser/seperate-provided-forms simple-addition-fact) => [simple-addition-fact]
-        (set  (#'smidje.parser/seperate-provided-forms
+        (#'smidje.parser.parser/seperate-provided-forms simple-addition-fact) => [simple-addition-fact]
+        (set  (#'smidje.parser.parser/seperate-provided-forms
                '((+ 1 1) => 2 :times 1 (* 2 3) => 6 :times 2 :except 3 (/ 4 2) => 2))) => '#{((+ 1 1) => 2 :times 1)
                                                                                       ((/ 4 2) => 2)
                                                                                      ((* 2 3) => 6 :times 2 :except 3)})
 
 (m/fact "build-provided-map"
-        (#'smidje.parser/build-provided-map simple-addition-fact) => {:mock-function '+
+        (#'smidje.parser.parser/build-provided-map simple-addition-fact) => {:mock-function '+
                                                                       :paramaters '(1 1)
                                                                       :arrow '=>
                                                                       :result 2}
-        (#'smidje.parser/build-provided-map '((add 2 3) => 5 :times 1 :except 4)) => {:mock-function 'add
+        (#'smidje.parser.parser/build-provided-map '((add 2 3) => 5 :times 1 :except 4)) => {:mock-function 'add
                                                                                       :paramaters '(2 3)
                                                                                       :arrow '=>
                                                                                       :result 5

--- a/test/smidje/cljs/macro_test.cljs
+++ b/test/smidje/cljs/macro_test.cljs
@@ -1,7 +1,8 @@
 (ns smidje.cljs.macro-test
   (:require-macros [cljs.test :refer [deftest is]]
-                   [smidje.parser :refer [fact]]
-                   [smidje.cljs-generator.test-builder :refer [testmacro]]))
+                   [smidje.core :refer [fact]]))
+
+(enable-console-print!)
 
 (defn bar []
   1)


### PR DESCRIPTION
The parser files where moved into a parser directory
the parser no longer calls the generator
fact in parser was renamed to factparser and turned into a function
core has the fact macro which delegates to factparser and passes the result to the generator
added a data model doc