### PR TITLE
adding syntax conversion

### DIFF
--- a/src/smidje/cljs_generator/cljs_syntax_converter.clj
+++ b/src/smidje/cljs_generator/cljs_syntax_converter.clj
@@ -5,14 +5,14 @@
   {"clojure.core" "cljs.core"
    "clojure.test" "cljs.test"})
 
-(defn generate-namespaced-symbol
+(defn- generate-namespaced-symbol
   "this will return a symbol with a new namespace applied if a mapping exists
   otherwise this returns the symbol using the specified namespace"
   [[namespace function]]
   (let [new-namespace (or (get namespace-map namespace) namespace)]
       (symbol (join "/" [new-namespace function]))))
 
-(defn convert-symbol
+(defn- convert-symbol
   "given a symbol this will return a clojurescript compatible symbol"
   [symbol]
   (let [parsed-symbol (split (str symbol) #"/")

--- a/src/smidje/cljs_generator/cljs_syntax_converter.clj
+++ b/src/smidje/cljs_generator/cljs_syntax_converter.clj
@@ -1,0 +1,32 @@
+(ns smidje.cljs-generator.cljs-syntax-converter
+  (:require [clojure.string :refer [split join]]))
+
+(def namespace-map
+  {"clojure.core" "cljs.core"
+   "clojure.test" "cljs.test"})
+
+(defn generate-namespaced-symbol
+  "this will return a symbol with a new namespace applied if a mapping exists
+  otherwise this returns the symbol using the specified namespace"
+  [[namespace function]]
+  (let [new-namespace (or (get namespace-map namespace) namespace)]
+      (symbol (join "/" [new-namespace function]))))
+
+(defn convert-symbol
+  "given a symbol this will return a clojurescript compatible symbol"
+  [symbol]
+  (let [parsed-symbol (split (str symbol) #"/")
+        symbol-count  (count parsed-symbol)]
+    (cond
+      (= symbol-count 1) symbol
+      (= symbol-count 2) (generate-namespaced-symbol parsed-symbol)
+      :else (throw (Exception. (str "could not convert symbol " symbol))))))
+
+(defn clj->cljs
+  "given a code snippet it will return a clojurescript compatible snippet"
+  [code]
+  (cond
+    (seq? code) (map clj->cljs code)
+    (vector? code) (into [] (map clj->cljs code))
+    (symbol? code) (convert-symbol code)
+    :else code))

--- a/src/smidje/cljs_generator/cljs_syntax_converter.clj
+++ b/src/smidje/cljs_generator/cljs_syntax_converter.clj
@@ -7,13 +7,17 @@
 
 (defn- generate-namespaced-symbol
   "this will return a symbol with a new namespace applied if a mapping exists
-  otherwise this returns the symbol using the specified namespace"
+  otherwise this returns the symbol with it's existing namespace. for example
+  clojure.test/is -> cljs.test/is
+  my.namespace/func -> my.namespace/func"
   [[namespace function]]
   (let [new-namespace (or (get namespace-map namespace) namespace)]
       (symbol (join "/" [new-namespace function]))))
 
 (defn- convert-symbol
-  "given a symbol this will return a clojurescript compatible symbol"
+  "given a symbol this will return a clojurescript compatible symbol for example
+  clojure.test/is -> cljs.test/is
+  func -> func"
   [symbol]
   (let [parsed-symbol (split (str symbol) #"/")
         symbol-count  (count parsed-symbol)]

--- a/src/smidje/cljs_generator/mocks.clj
+++ b/src/smidje/cljs_generator/mocks.clj
@@ -1,17 +1,18 @@
 (ns smidje.cljs-generator.mocks)
 
 (defn generate-mock-function
-  "generates a mock given a mock-data object of the form
-  {<param-list> {:result <return value>
-                 :calls  <expected times called>
-                 :arrow  '=>}}"
-  [function mock-config-atom]
-  `(cljs.core/fn [& params#]
-     (let [mock-config# (cljs.core/get-in (cljs.core/deref ~mock-config-atom) [~function :mock-config])
+  "generates a mock given a mock-config-atom object of the form
+  {<function-key>
+    {:mock-config
+      {<arg>
+        {:result [<values to return>]
+         :arrow  <arrow>}}}}"
+  [function-key mock-config-atom]
+  `(fn [& params#]
+     (let [mock-config# (get-in @~mock-config-atom [~function-key :mock-config])
            clean-params# (or params# [])]
-       (cljs.core/swap! ~mock-config-atom cljs.core/update-in [~function :calls clean-params#] (cljs.core/fnil cljs.core/inc 0))
-       ;(cljs.core/println (cljs.core/deref ~mock-config-atom))
+       (swap! ~mock-config-atom update-in [~function-key :calls clean-params#] (fnil inc 0))
        (if
-         (cljs.core/contains? mock-config# clean-params#)
-         (cljs.core/get-in mock-config# [clean-params# :result])
+         (contains? mock-config# clean-params#)
+         (get-in mock-config# [clean-params# :result])
          nil))))

--- a/test/smidje/clj/cljs_generator/cljs_syntax_converter_test.clj
+++ b/test/smidje/clj/cljs_generator/cljs_syntax_converter_test.clj
@@ -1,0 +1,27 @@
+(ns smidje.clj.cljs-generator.cljs-syntax-converter-test
+  (:require [midje.sweet :refer :all]
+            [smidje.cljs-generator.cljs-syntax-converter :refer :all]))
+
+(facts
+  "clj->cljs works as expected"
+  (tabular
+    (fact
+      "clj->cljs correctly maps namespaces"
+      (clj->cljs ?code) => ?result)
+      ?code                   ?result
+      'symbol                 'symbol
+      'clojure.core/fn        'cljs.core/fn
+      'clojure.test/is        'cljs.test/is
+      'unknown.namespace/func 'unknown.namespace/func)
+  (fact
+    "clj->cljs returns vector given vector"
+    (clj->cljs [..symbol..]) => vector?)
+
+  (fact
+    "clj->cljs returns a list given a list"
+    (clj->cljs '(..symbol..)) => seq?)
+
+  (fact
+    "clj->cljs handles nested namespaces"
+    (clj->cljs
+      '(clojure.core/func ['clojure.test/func2 '(1 2 3 'namespce/func3)])) => '(cljs.core/func ['cljs.test/func2 '(1 2 3 'namespce/func3)])))

--- a/test/smidje/clj/cljs_generator/test_builder_test.clj
+++ b/test/smidje/clj/cljs_generator/test_builder_test.clj
@@ -3,40 +3,43 @@
             [smidje.clj.intermediate-maps :as im]
             [smidje.cljs-generator.test-builder :refer :all]))
 
-(background (clojure.test/report anything) => {})
+(defmulti new-report (fn [& args] :default))
+(defmethod new-report :default [& args] {})
 
-(facts
-  "generate-single-assert with normal arrow"
-  (fact
-    "successful assertion with constant succeeds"
-    (eval (generate-single-assert im/simple-successful-addition-assertion)) => true)
-  (fact
-    "failed assertion with constant fails"
-    (eval (generate-single-assert im/simple-failing-addition-assertion)) => false)
-  (fact
-    "successful assertion with checker function succeeds"
-    (eval (generate-single-assert im/simple-successful-checker-function-assertion)) => true)
-  (fact
-    "failed assertion with checker function fails"
-    (eval (generate-single-assert im/simple-failed-checker-function-assertion)) => false))
+(with-redefs [clojure.test/report new-report]               ;required to suppress clojure.test output from methods under test
 
-(facts
-  "generate-single-assert with not arrow"
-  (fact
-    "successful assertion with constant succeeds"
-    (eval (generate-single-assert im/simple-addition-successful-not-assertion)) => true)
-  (fact
-    "failed assertion with constant fails"
-    (eval (generate-single-assert im/simple-addition-failed-not-assertion)) => false))
+  (facts
+    "generate-single-assert with normal arrow"
+    (fact
+      "successful assertion with constant succeeds"
+      (eval (generate-single-assert im/simple-successful-addition-assertion)) => true)
+    (fact
+      "failed assertion with constant fails"
+      (eval (generate-single-assert im/simple-failing-addition-assertion)) => false)
+    (fact
+      "successful assertion with checker function succeeds"
+      (eval (generate-single-assert im/simple-successful-checker-function-assertion)) => true)
+    (fact
+      "failed assertion with checker function fails"
+      (eval (generate-single-assert im/simple-failed-checker-function-assertion)) => false))
 
-(fact "simple throws form correct"
-      (generate-expected-exception im/expected-exception-assertion)
-      => '(clojure.test/is (thrown? Exception (smidje.clj.intermediate-maps/foo nil))))
+  (facts
+    "generate-single-assert with not arrow"
+    (fact
+      "successful assertion with constant succeeds"
+      (eval (generate-single-assert im/simple-addition-successful-not-assertion)) => true)
+    (fact
+      "failed assertion with constant fails"
+      (eval (generate-single-assert im/simple-addition-failed-not-assertion)) => false))
 
-(tabular
- (fact "arrows generate correct equality checks"
-       (do-arrow ?arrow) => ?expected)
- ?arrow     ?expected
- '=>        '=
- '=not=>    'not=
- '=bogus=>  (throws Exception))
+  (fact "simple throws form correct"
+        (generate-expected-exception im/expected-exception-assertion)
+        => '(clojure.test/is (thrown? Exception (smidje.clj.intermediate-maps/foo nil))))
+
+  (tabular
+    (fact "arrows generate correct equality checks"
+          (do-arrow ?arrow) => ?expected)
+    ?arrow ?expected
+    '=> '=
+    '=not=> 'not=
+    '=bogus=> (throws Exception)))

--- a/test/smidje/clj/cljs_generator/test_builder_test.clj
+++ b/test/smidje/clj/cljs_generator/test_builder_test.clj
@@ -1,28 +1,42 @@
 (ns smidje.clj.cljs-generator.test-builder-test
   (:require [midje.sweet :refer :all]
-            [smidje.clj.parser.intermediate-maps :as im]
+            [smidje.clj.intermediate-maps :as im]
             [smidje.cljs-generator.test-builder :refer :all]))
 
-(fact "a single expect match arrow fact"
-      (generate-single-assert im/simple-addition-assertion)
-      => `(cljs.core/cond
-            (cljs.core/fn? 2) (cljs.test/is (cljs.core/= (2 (~'+ 1 1)) true))
-            :else (cljs.test/is (cljs.core/= (~'+ 1 1) 2))))
+(background (clojure.test/report anything) => {})
 
-(fact "a single not assertion fact"
-      (generate-single-assert im/simple-addtion-not-assertion)
-      => `(cljs.core/cond
-            (cljs.core/fn? 3) (cljs.test/is (cljs.core/not= (3 (~'+ 1 1)) true))
-            :else (cljs.test/is (cljs.core/not= (~'+ 1 1) 3))))
+(facts
+  "generate-single-assert with normal arrow"
+  (fact
+    "successful assertion with constant succeeds"
+    (eval (generate-single-assert im/simple-successful-addition-assertion)) => true)
+  (fact
+    "failed assertion with constant fails"
+    (eval (generate-single-assert im/simple-failing-addition-assertion)) => false)
+  (fact
+    "successful assertion with checker function succeeds"
+    (eval (generate-single-assert im/simple-successful-checker-function-assertion)) => true)
+  (fact
+    "failed assertion with checker function fails"
+    (eval (generate-single-assert im/simple-failed-checker-function-assertion)) => false))
 
-(fact "simple throws"
+(facts
+  "generate-single-assert with not arrow"
+  (fact
+    "successful assertion with constant succeeds"
+    (eval (generate-single-assert im/simple-addition-successful-not-assertion)) => true)
+  (fact
+    "failed assertion with constant fails"
+    (eval (generate-single-assert im/simple-addition-failed-not-assertion)) => false))
+
+(fact "simple throws form correct"
       (generate-expected-exception im/expected-exception-assertion)
-      => '(cljs.test/is (thrown? InvalidFooError (foo nil))))
+      => '(clojure.test/is (thrown? Exception (smidje.clj.intermediate-maps/foo nil))))
 
 (tabular
  (fact "arrows generate correct equality checks"
        (do-arrow ?arrow) => ?expected)
  ?arrow     ?expected
- '=>        'cljs.core/=
- '=not=>    'cljs.core/not=
+ '=>        '=
+ '=not=>    'not=
  '=bogus=>  (throws Exception))

--- a/test/smidje/clj/intermediate_maps.clj
+++ b/test/smidje/clj/intermediate_maps.clj
@@ -1,18 +1,42 @@
-(ns smidje.clj.parser.intermediate-maps)
+(ns smidje.clj.intermediate-maps)
 
 (def test-metadata
   {:smidje/namespace 'smidje.core-test
    :smidje/file ""})
 
-(def simple-addition-assertion
+(def simple-successful-addition-assertion
   {:expected-result-form `'2
    :expected-result 2
    :arrow '=>
    :call-form '(+ 1 1)})
 
-(def simple-addtion-not-assertion
+(def simple-failing-addition-assertion
+  {:expected-result-form `'2
+   :expected-result 3
+   :arrow '=>
+   :call-form '(+ 1 1)})
+
+(def simple-successful-checker-function-assertion
+  {:expected-result-form 'even?
+   :expected-result even?
+   :arrow '=>
+   :call-form '(+ 1 1)})
+
+(def simple-failed-checker-function-assertion
+  {:expected-result-form 'odd?
+   :expected-result odd?
+   :arrow '=>
+   :call-form '(+ 1 1)})
+
+(def simple-addition-successful-not-assertion
   {:expected-result-form `'3
    :expected-result 3
+   :arrow '=not=>
+   :call-form '(+ 1 1)})
+
+(def simple-addition-failed-not-assertion
+  {:expected-result-form `'2
+   :expected-result 2
    :arrow '=not=>
    :call-form '(+ 1 1)})
 
@@ -34,10 +58,12 @@
    :provided {:mock-function 'foo
               :return provided-mock-config}})
 
+(defn foo [& args] (throw (Exception.)))
+
 (def expected-exception-assertion
-  {:call-form '(foo nil)
+  {:call-form `(foo nil)
    :arrow '=>
-   :throws-exception 'InvalidFooError})
+   :throws-exception 'Exception})
 
 (defn expect-match-map [name & assertions]
   (merge
@@ -46,14 +72,14 @@
              :assertions assertions}]}))
 
 (def single-expect-match-map (expect-match-map "addition is simple"
-                                               simple-addition-assertion))
+                                               simple-successful-addition-assertion))
 
 (def multiple-expect-match-map (expect-match-map "more addition testing"
-                                                 simple-addition-assertion
+                                                 simple-successful-addition-assertion
                                                  ternary-addition-assertion))
 
 (def single-expect-unequal-map (expect-match-map "addition is well defined"
-                                                 simple-addtion-not-assertion))
+                                                 simple-addition-successful-not-assertion))
 
 (def single-provided-expect-match-map (expect-match-map "universal question"
                                                         provided-assertion))

--- a/test/smidje/clj/parser/parser_test.clj
+++ b/test/smidje/clj/parser/parser_test.clj
@@ -1,6 +1,6 @@
 (ns smidje.clj.parser.parser-test
   (:require [midje.sweet :as m]
-            [smidje.clj.parser.intermediate-maps :as im]
+            [smidje.clj.intermediate-maps :as im]
             [smidje.parser.parser :as parser :refer :all])
   (:use     [midje.util :only [expose-testables]]))
 
@@ -12,13 +12,13 @@
   '((+ 1 1) => 2))
 
 (m/fact "simple addition"
-        (parser/parse simple-addition-fact) => [im/simple-addition-assertion])
+        (parser/parse simple-addition-fact) => [im/simple-successful-addition-assertion])
 
 (def simple-addition-unequal-fact
   '((+ 1 1) =not=> 3))
 
 (m/fact "simple addition unequal"
-        (parser/parse simple-addition-unequal-fact) => [im/simple-addtion-not-assertion])
+        (parser/parse simple-addition-unequal-fact) => [im/simple-addition-successful-not-assertion])
 
 (m/fact "throws validator recognizes right hand expected exception"
   (throws-form? '(throws)) => true


### PR DESCRIPTION
I have to fix broken tests and add tests but I want some feedback on the thought process. In a nutshell this will allow us to write the macros as though it were for clojure and convert the namespaces as the last step. This should simplify making changes and it will allow us to test our generated code by executing it rather then just checking that it is templated correctly. 