### PR TITLE
Replace metaconstants

### DIFF
--- a/doc/data-model.md
+++ b/doc/data-model.md
@@ -9,7 +9,7 @@ the map into cljs-test syntax.
 {:namespace ""
  :tests [{
             :name ""
-            :metaconstants [...]
+            :metaconstants {...}
             :assertions [{
                             :function-under-test ""
                             :call-form ""
@@ -28,7 +28,8 @@ the map into cljs-test syntax.
 `:namespace`- The namespace of the fact.  
 `:tests`- A vector of facts (this will be used for nesting which is not supported yet).  
 `:name`- The name of a single fact.  
-`:metaconstants`- A vector of metaconstant keywords that need to be bound for the assertions.
+`:metaconstants`- A map of metaconstants info, with keys set to the metaconstant symbol as a keyword, and values
+set to generated symbols that the metaconstant is replaced with in the adjusted form.
 `:assertions`- A vector of assertions which are individual arrow statements for example `(+ 1 1) => 2`  
 `:function-under-test`- Quoted form of the function under test (the left side of the arrow)  
 `:call-form`- The unquoted function under test  

--- a/doc/data-model.md
+++ b/doc/data-model.md
@@ -28,7 +28,8 @@ the map into cljs-test syntax.
 `:namespace`- The namespace of the fact.  
 `:tests`- A vector of facts (this will be used for nesting which is not supported yet).  
 `:name`- The name of a single fact.  
-`:metaconstants`- A map of metaconstants info, with keys set to the metaconstant symbol as a keyword, and values
+`:metaconstants`- A map of metaconstant info, with keys set to a generated, bindable symbol that can represent the
+ metaconstant in test generation, mapped to the original metaconstant symbol.
 set to generated symbols that the metaconstant is replaced with in the adjusted form.
 `:assertions`- A vector of assertions which are individual arrow statements for example `(+ 1 1) => 2`  
 `:function-under-test`- Quoted form of the function under test (the left side of the arrow)  

--- a/src/smidje/parser/parser.clj
+++ b/src/smidje/parser/parser.clj
@@ -161,7 +161,6 @@
   (->> (vector form)
        (flatten)
        (filter metaconstant?)
-       (map keyword)
        (distinct)))
 
 (defn- gen-metaconstant-sym [mc]
@@ -184,7 +183,7 @@
 (defn- replace-metaconstant
   [mc-lookup form]
   (if (metaconstant? form)
-    (get mc-lookup (keyword (name form)))
+    (get mc-lookup form)
     form))
 
 (defn- ^{:testable true} replace-metaconstants
@@ -238,4 +237,4 @@
         adjusted-forms (replace-metaconstants metaconstants fact-forms)]
     (-> {:tests [{:name       name
                   :assertions (parse adjusted-forms)
-                  :metaconstants metaconstants}]})))
+                  :metaconstants (clojure.set/map-invert metaconstants)}]})))

--- a/src/smidje/parser/parser.clj
+++ b/src/smidje/parser/parser.clj
@@ -157,27 +157,28 @@
        (metaconstant-name? (name element))))
 
 (defn- pre-parse-metaconstants
+  "Returns a list of unique metaconstants symbols in the form.
+   The form can be a single element or a variably-nested list."
   [form]
   (->> (vector form)
        (flatten)
        (filter metaconstant?)
        (distinct)))
 
-(defn- gen-metaconstant-sym [mc]
+(defn- gen-metaconstant-sym
+  "Generates a unique, bindable symbol for the metaconstant symbol."
+  [mc]
   (let [mc-name (name mc)
         mc-length (count mc-name)
         mc-undecorated-name (subs mc-name 2 (- mc-length 2))
         mc-prefix (if (= (subs mc-name 0 2) "..") "dot" "dash")]
     (gensym (str "smidje->mc->" mc-prefix "->" mc-undecorated-name "->"))))
 
-(defn- gen-metaconstant-syms
-  [metaconstants]
-  (map gen-metaconstant-sym metaconstants))
-
 (defn parse-metaconstants
+  "Takes a form and returns a map of unique metaconstants in the form mapped to bindable names generated for each."
   [form]
   (let [metaconstants (pre-parse-metaconstants form)
-        swapped (gen-metaconstant-syms metaconstants)]
+        swapped (map gen-metaconstant-sym metaconstants)]
     (zipmap metaconstants swapped)))
 
 (defn- replace-metaconstant
@@ -187,6 +188,8 @@
     form))
 
 (defn- ^{:testable true} replace-metaconstants
+  "Takes a metaconstant->symbol look-up map and a variably nested form. Returns the form with metaconstant values
+   replaced by the values in the look-up map."
   [mc-lookup form]
   (if-not (seq? form)
     (replace-metaconstant mc-lookup form)

--- a/test/smidje/clj/parser/parser_test.clj
+++ b/test/smidje/clj/parser/parser_test.clj
@@ -101,19 +101,68 @@
   'foo      m/FALSEY)
 
 (m/facts "about `parse-metaconstants`"
-  (m/fact "returns an empty list for non-metaconstant single input"
-          (parse-metaconstants ..form..) => []
+  (m/fact "returns an empty map for non-metaconstant single input"
+          (parse-metaconstants ..form..) => {}
           (m/provided
             (#'smidje.parser.parser/metaconstant? ..form..) m/=> false))
   (m/fact "returns list of expected consants given list"
-          (parse-metaconstants '(hi ..hello.. "..there..")) => [:..hello..]
-          (parse-metaconstants '(this "returns" nothing)) => []
-          (parse-metaconstants '..foo..) => [:..foo..]
+          (parse-metaconstants '(this "returns" nothing)) => {}
+
+          (parse-metaconstants '(hi ..hello.. "..there..")) => {:..hello.. ..gensym..}
+          (m/provided
+            (gensym "smidje->mc->dot->hello->") m/=> ..gensym..)
+
+          (parse-metaconstants '..foo..) => {:..foo.. ..gensym..}
+          (m/provided
+            (gensym "smidje->mc->dot->foo->") m/=> ..gensym..)
+
           (parse-metaconstants '(duplicates ..are.. --not-- --not-- --not-- a problem))
-                                => [:..are.. :--not--]
+          => {:..are.. ..gensym1..
+              :--not-- ..gensym2..}
+          (m/provided
+            (gensym "smidje->mc->dot->are->") m/=> ..gensym1..
+            (gensym "smidje->mc->dash->not->") m/=> ..gensym2..)
+
           (parse-metaconstants '(--also-- (..it.. (--will--) --flatten--)))
-                                => [:--also-- :..it.. :--will-- :--flatten--]
+          => {:--also--    ..gensym1..
+              :..it..      ..gensym2..
+              :--will--    ..gensym3..
+              :--flatten-- ..gensym4..}
+          (m/provided
+            (gensym "smidje->mc->dash->also->") m/=> ..gensym1..
+            (gensym "smidje->mc->dot->it->") m/=> ..gensym2..
+            (gensym "smidje->mc->dash->will->") m/=> ..gensym3..
+            (gensym "smidje->mc->dash->flatten->") m/=> ..gensym4..)
+
           (parse-metaconstants '(mixed --flattened-- (inputs "--cause--" (--no-- problems) ..either..)))
-                                => [:--flattened-- :--no-- :..either..]
+          => {:--flattened-- ..gensym1..
+              :--no--        ..gensym2..
+              :..either..    ..gensym3..}
+          (m/provided
+            (gensym "smidje->mc->dash->flattened->") m/=> ..gensym1..
+            (gensym "smidje->mc->dash->no->") m/=> ..gensym2..
+            (gensym "smidje->mc->dot->either->") m/=> ..gensym3..)
+
           (parse-metaconstants '((something --foo-- ..input..) => ..result.. (provided (--foo-- ..input..) => ..result)))
-                                => [:--foo-- :..input.. :..result..]))
+          => {:--foo--    ..gensym1..
+              :..input..  ..gensym2..
+              :..result.. ..gensym3..}
+          (m/provided
+            (gensym "smidje->mc->dash->foo->") m/=> ..gensym1..
+            (gensym "smidje->mc->dot->input->") m/=> ..gensym2..
+            (gensym "smidje->mc->dot->result->") m/=> ..gensym3..)))
+
+(m/fact "`replace-metaconstants` replaceces metaconstant symbols with values in symbol table"
+        (replace-metaconstants {} "foo") => "foo"
+
+        (replace-metaconstants {} '(nothing to see here)) => '(nothing to see here)
+
+        (replace-metaconstants
+          {:--foo-- ..gensym1.. :..foo.. ..gensym2..}
+          '(this --foo-- ..foo..))
+        => '(this ..gensym1.. ..gensym2..)
+
+        (replace-metaconstants
+          {:--mc1-- ..gensym1.. :..mc1.. ..gensym2.. :..mc2.. ..gensym3..}
+          '(--mc1-- ..mc1.. (--mc1-- "..mc1.." ..mc2.. (..mc2.. "foo") ..mc1..)))
+        => '(..gensym1.. ..gensym2.. (..gensym1.. "..mc1.." ..gensym3.. (..gensym3.. "foo") ..gensym2..)))

--- a/test/smidje/clj/parser/parser_test.clj
+++ b/test/smidje/clj/parser/parser_test.clj
@@ -108,26 +108,26 @@
   (m/fact "returns list of expected consants given list"
           (parse-metaconstants '(this "returns" nothing)) => {}
 
-          (parse-metaconstants '(hi ..hello.. "..there..")) => {:..hello.. ..gensym..}
+          (parse-metaconstants '(hi ..hello.. "..there..")) => {'..hello.. ..gensym..}
           (m/provided
             (gensym "smidje->mc->dot->hello->") m/=> ..gensym..)
 
-          (parse-metaconstants '..foo..) => {:..foo.. ..gensym..}
+          (parse-metaconstants '..foo..) => {'..foo.. ..gensym..}
           (m/provided
             (gensym "smidje->mc->dot->foo->") m/=> ..gensym..)
 
           (parse-metaconstants '(duplicates ..are.. --not-- --not-- --not-- a problem))
-          => {:..are.. ..gensym1..
-              :--not-- ..gensym2..}
+          => {'..are.. ..gensym1..
+              '--not-- ..gensym2..}
           (m/provided
             (gensym "smidje->mc->dot->are->") m/=> ..gensym1..
             (gensym "smidje->mc->dash->not->") m/=> ..gensym2..)
 
           (parse-metaconstants '(--also-- (..it.. (--will--) --flatten--)))
-          => {:--also--    ..gensym1..
-              :..it..      ..gensym2..
-              :--will--    ..gensym3..
-              :--flatten-- ..gensym4..}
+          => {'--also--    ..gensym1..
+              '..it..      ..gensym2..
+              '--will--    ..gensym3..
+              '--flatten-- ..gensym4..}
           (m/provided
             (gensym "smidje->mc->dash->also->") m/=> ..gensym1..
             (gensym "smidje->mc->dot->it->") m/=> ..gensym2..
@@ -135,18 +135,18 @@
             (gensym "smidje->mc->dash->flatten->") m/=> ..gensym4..)
 
           (parse-metaconstants '(mixed --flattened-- (inputs "--cause--" (--no-- problems) ..either..)))
-          => {:--flattened-- ..gensym1..
-              :--no--        ..gensym2..
-              :..either..    ..gensym3..}
+          => {'--flattened-- ..gensym1..
+              '--no--        ..gensym2..
+              '..either..    ..gensym3..}
           (m/provided
             (gensym "smidje->mc->dash->flattened->") m/=> ..gensym1..
             (gensym "smidje->mc->dash->no->") m/=> ..gensym2..
             (gensym "smidje->mc->dot->either->") m/=> ..gensym3..)
 
           (parse-metaconstants '((something --foo-- ..input..) => ..result.. (provided (--foo-- ..input..) => ..result)))
-          => {:--foo--    ..gensym1..
-              :..input..  ..gensym2..
-              :..result.. ..gensym3..}
+          => {'--foo--    ..gensym1..
+              '..input..  ..gensym2..
+              '..result.. ..gensym3..}
           (m/provided
             (gensym "smidje->mc->dash->foo->") m/=> ..gensym1..
             (gensym "smidje->mc->dot->input->") m/=> ..gensym2..
@@ -158,11 +158,11 @@
         (replace-metaconstants {} '(nothing to see here)) => '(nothing to see here)
 
         (replace-metaconstants
-          {:--foo-- ..gensym1.. :..foo.. ..gensym2..}
+          {'--foo-- ..gensym1.. '..foo.. ..gensym2..}
           '(this --foo-- ..foo..))
         => '(this ..gensym1.. ..gensym2..)
 
         (replace-metaconstants
-          {:--mc1-- ..gensym1.. :..mc1.. ..gensym2.. :..mc2.. ..gensym3..}
+          {'--mc1-- ..gensym1.. '..mc1.. ..gensym2.. '..mc2.. ..gensym3..}
           '(--mc1-- ..mc1.. (--mc1-- "..mc1.." ..mc2.. (..mc2.. "foo") ..mc1..)))
         => '(..gensym1.. ..gensym2.. (..gensym1.. "..mc1.." ..gensym3.. (..gensym3.. "foo") ..gensym2..)))


### PR DESCRIPTION
Metaconstant symbols can't be bound in a let, so we're now doing find/replace step in the parser after collecting metaconstant data and generating corresponding symbols for each.