### PR TITLE
adding warning for no assertions

### DIFF
--- a/src/smidje/cljs_generator/test_builder.clj
+++ b/src/smidje/cljs_generator/test_builder.clj
@@ -102,15 +102,16 @@
         (reduce concat)
         (into [])))
 
-(defn generate-test [test-definition]
-  (let [{assertions# :assertions
-         name# :name
-         metaconstants# :metaconstants} test-definition]
-    `(deftest ~(symbol name#)
-       (let ~(generate-metaconstant-bindings metaconstants#)
-         ~@(map
-             (partial generate-wrapped-assertion metaconstants#)
-             assertions#)))))
+(defn generate-test [{assertions# :assertions
+                      name# :name
+                      metaconstants# :metaconstants}]
+  (cond
+    (empty? assertions#) `(print "warning:" ~name# "does not have any assertions and will be ignored")
+    :else `(deftest ~(symbol name#)
+             (let ~(generate-metaconstant-bindings metaconstants#)
+               ~@(map
+                   (partial generate-wrapped-assertion metaconstants#)
+                   assertions#)))))
 
 (defn generate-tests [test-runtime]
   (let [tests# (:tests test-runtime)]

--- a/src/smidje/core.cljc
+++ b/src/smidje/core.cljc
@@ -1,6 +1,7 @@
 (ns smidje.core
   (:require #?(:clj [smidje.cljs-generator.test-builder :as cljs-builder])
             #?(:clj [smidje.parser.parser :as parser])
+            #?(:cljs [cljs.test :refer-macros [deftest is]])
             [smidje.cljs-generator.mocks :as mocks]))
 
 (defmacro fact [& args]

--- a/src/smidje/parser/parser.clj
+++ b/src/smidje/parser/parser.clj
@@ -134,7 +134,7 @@
       (parse-expected expected-form)
       (parse-provided forms))))
 
-(defn parse
+(defn parse-assertions
   [forms]
   (loop [result []
          input forms]
@@ -239,5 +239,5 @@
         metaconstants (parse-metaconstants fact-forms)
         adjusted-forms (replace-metaconstants metaconstants fact-forms)]
     (-> {:tests [{:name       name
-                  :assertions (parse adjusted-forms)
+                  :assertions (parse-assertions adjusted-forms)
                   :metaconstants (clojure.set/map-invert metaconstants)}]})))

--- a/test/smidje/clj/cljs_generator/test_builder_test.clj
+++ b/test/smidje/clj/cljs_generator/test_builder_test.clj
@@ -82,3 +82,7 @@
   [1 2]     1             truthy
   [1 2]     5             falsey
   nil       2             falsey)
+
+(fact
+  "empty assertions results in print"
+  (generate-test {:assertions [] :name ..test-name..}) => `(print "warning:" ..test-name.. "does not have any assertions and will be ignored"))

--- a/test/smidje/clj/parser/parser_test.clj
+++ b/test/smidje/clj/parser/parser_test.clj
@@ -12,13 +12,13 @@
   '((+ 1 1) => 2))
 
 (m/fact "simple addition"
-        (parser/parse simple-addition-fact) => [im/simple-successful-addition-assertion])
+        (parser/parse-assertions simple-addition-fact) => [im/simple-successful-addition-assertion])
 
 (def simple-addition-unequal-fact
   '((+ 1 1) =not=> 3))
 
 (m/fact "simple addition unequal"
-        (parser/parse simple-addition-unequal-fact) => [im/simple-addition-successful-not-assertion])
+        (parser/parse-assertions simple-addition-unequal-fact) => [im/simple-addition-successful-not-assertion])
 
 (m/fact "throws validator recognizes right hand expected exception"
   (throws-form? '(throws)) => true

--- a/test/smidje/cljs/macro_test.cljs
+++ b/test/smidje/cljs/macro_test.cljs
@@ -1,6 +1,5 @@
 (ns smidje.cljs.macro-test
-  (:require [smidje.core :refer-macros [fact tabular]])
-  (:require-macros [cljs.test :refer [deftest is]]))
+  (:require [smidje.core :refer-macros [fact tabular]]))
 
 (enable-console-print!)
 
@@ -67,3 +66,5 @@
   (thing 1) =not=> ..result..
   (provided
     (thing 1) => ..badresult..))
+
+(fact "expected empty fact warning")


### PR DESCRIPTION
While developing I sometimes break tests but not in a way that they fail, just that no assertions are generated, this is a small quality of life change.