### PR TITLE
Parse times

### DIFF
--- a/src/smidje/cljs_generator/mocks.cljc
+++ b/src/smidje/cljs_generator/mocks.cljc
@@ -30,8 +30,34 @@
 
 (defn validate-mock-called-with-expected-args [function mock-info]
   (doseq [expected-call-param (keys (:mock-config mock-info))]
-    (is (>= (or (get (:calls mock-info) expected-call-param) 0) 1)
-        (str function " expected to be called with " expected-call-param " but never invoked"))))
+    (let [mock-config (:mock-config mock-info)
+          call-info (get mock-config (first (keys mock-config)))
+          times-called (or (get (:calls mock-info) expected-call-param) 0)
+          function-string (str "(" function " " expected-call-param ")")]
+      (if-let [times-info (:times call-info)]
+        (cond
+          ; optional number of times: no validation
+          (= times-info :optional) (do)
+          ; exact call count specified
+          (integer? times-info)
+            (is (= times-called times-info)
+                (str function-string " expected to be called " times-info " times; was called " times-called " times"))
+          ; range of acceptable values specified
+          (contains? times-info :range)
+            (let [min (first (:range times-info))
+                  max (second (:range times-info))
+                  error (str function-string " expected to be called "
+                             min " to " max " times, was called " times-called " time(s)")]
+              (is (>= times-called min) error)
+              (is (<= times-called max) error))
+          ; shouldn't get here, but just in case
+          :else
+            (throw (RuntimeException. "unsupported use of :times in (provided)")))
+        ; default: require one or more
+        (is (>= (or (get (:calls mock-info) expected-call-param) 0) 1)
+            (str function-string " expected to be called, but never invoked"))
+        )
+      )))
 
 (defn validate-mocks [mocks-atom]
   (doseq [[function mock] @mocks-atom]

--- a/src/smidje/cljs_generator/mocks.cljc
+++ b/src/smidje/cljs_generator/mocks.cljc
@@ -31,8 +31,8 @@
 (defn validate-mock-called-with-expected-args [function mock-info]
   (doseq [expected-call-param (keys (:mock-config mock-info))]
     (let [mock-config (:mock-config mock-info)
-          call-info (get mock-config (first (keys mock-config)))
           times-called (or (get (:calls mock-info) expected-call-param) 0)
+          call-info (get mock-config (first (keys mock-config)))
           function-string (str "(" function " " expected-call-param ")")]
       (if-let [times-info (:times call-info)]
         (cond

--- a/src/smidje/core.cljc
+++ b/src/smidje/core.cljc
@@ -18,23 +18,3 @@
 
 (defn validate-mocks [mocks-atom]
   (mocks/validate-mocks mocks-atom))
-
-(comment
-  (macroexpand
-    '(fact "what a fact"
-           (+ 1 1) => 2
-           (+ 2 2) =not=> 3
-           "hi" => truthy
-           true => TRUTHY
-           false => FALSEY
-           (/ 2 0) => (throws ArithmeticException)
-           (/ 4 0) => (throws ArithmeticException "Divide by zero")))
-
-  (macroexpand
-   '(tabular "test name"
-             (fact "fact name"
-                   (+ ?a ?b) => ?c)
-             ?a ?b ?c
-             1  2  3
-             3  4  7))
-  )

--- a/src/smidje/parser/parser.clj
+++ b/src/smidje/parser/parser.clj
@@ -74,9 +74,9 @@
            (> (count input) 1)
            (list? (second input))
            (= (first (second input)) 'range))
-      (recur
-        (conj result (first input) (replace-range (second input)))
-        (drop 2 input))
+        (recur
+          (conj result (first input) (replace-range (second input)))
+          (drop 2 input))
       :else (recur
               (conj result (first input))
               (rest input)))))

--- a/src/smidje/parser/parser.clj
+++ b/src/smidje/parser/parser.clj
@@ -1,8 +1,7 @@
 (ns smidje.parser.parser
   (:require [smidje.parser.arrows :refer [arrow-set]]
             [clojure.walk :refer [prewalk]]
-            [smidje.parser.checkers :refer [throws truthy TRUTHY falsey FALSEY]])
-  (:import (java.text ParseException)))
+            [smidje.parser.checkers :refer [throws truthy TRUTHY falsey FALSEY]]))
 
 (def provided "provided")
 

--- a/src/smidje/parser/parser.clj
+++ b/src/smidje/parser/parser.clj
@@ -65,7 +65,7 @@
     3 {:range [(nth form 1) (nth form 2)]}
     (throw (RuntimeException. "invalid (range) form: more than two arguments"))))
 
-(defn- adjust-range
+(defn- ^{:testable true} adjust-range
   [form]
   (loop [result [] input form]
     (cond

--- a/src/smidje/parser/parser.clj
+++ b/src/smidje/parser/parser.clj
@@ -59,11 +59,18 @@
 
 (defn- replace-range
   [form]
-  (condp = (count form)
-    1 :optional
-    2 {:range [0 (second form)]}
-    3 {:range [(nth form 1) (nth form 2)]}
-    (throw (RuntimeException. "invalid (range) form: more than two arguments"))))
+  (let [[_ x1 x2] form]
+    (condp = (count form)
+      1 :optional
+      2 (if (< x1 1)
+          (throw (RuntimeException. (str "invalid (range) argument: " x1 ", must be greater than 0")))
+          {:range [1 x1]})
+      3 (cond
+          (< x1 1) (throw (RuntimeException. (str "invalid (range) argument: " x1 " must be greater than 0")))
+          (< x2 1) (throw (RuntimeException. (str "invalid (range) argument: " x2 " must be greater than 0")))
+          (> x1 x2) (throw (RuntimeException. (str "invalid (range) argument: " x1 " must be less than or equal to " x2)))
+          :else {:range [x1 x2]})
+      (throw (RuntimeException. "invalid (range) form: more than two arguments")))))
 
 (defn- ^{:testable true} adjust-range
   [form]

--- a/test/smidje/clj/cljs_generator/mock_tests.clj
+++ b/test/smidje/clj/cljs_generator/mock_tests.clj
@@ -81,6 +81,63 @@
         (do-report (as-checker #(= :fail (:type %)))) => nil :times 1)))
 
   (fact
+    "validate-mock-called-with-expected-args passes when indicated :times calls made"
+    (let [function 'func
+          mock-config {:mock-config {[] {:result ..foo.. :times 2}},
+                       :calls       {[] 2}}]
+      (validate-mock-called-with-expected-args function mock-config) => anything
+      (provided
+        (do-report (as-checker #(= :pass (:type %)))) => nil :times 1))
+    (let [function 'func
+          mock-config {:mock-config {[] {:result ..foo.. :times 0}}}]
+      (validate-mock-called-with-expected-args function mock-config) => anything
+      (provided
+        (do-report (as-checker #(= :pass (:type %)))) => nil :times 1)))
+
+  (fact
+    "validate-mock-called-with-expected-args fails when indicated :times calls not made"
+    (let [function 'func
+          mock-config {:mock-config {[] {:result ..foo.. :times 3}},
+                       :calls       {[] 2}}]
+      (validate-mock-called-with-expected-args function mock-config) => anything
+      (provided
+        (do-report (as-checker #(= :fail (:type %)))) => nil :times 1)))
+
+  (fact
+    "validate-mock-called-with-expected-args passes when indicated :times range calls made"
+    (let [function 'func
+          mock-config {:mock-config {[] {:result ..foo.. :times {:range [5 6]}}},
+                       :calls       {[] 5}}]
+      (validate-mock-called-with-expected-args function mock-config) => anything
+      (provided
+        (do-report (as-checker #(= :pass (:type %)))) => nil :times 2))
+    (let [function 'func
+          mock-config {:mock-config {[] {:result ..foo.. :times {:range [2 7]}}},
+                       :calls       {[] 7}}]
+      (validate-mock-called-with-expected-args function mock-config) => anything
+      (provided
+        (do-report (as-checker #(= :pass (:type %)))) => nil :times 2)))
+
+  (fact
+    "validate-mock-called-with-expected-args fails when indicated :times range calls made"
+    (let [function 'func
+          mock-config {:mock-config {[] {:result ..foo.. :times {:range [2 5]}}},
+                       :calls       {[] 7}}]
+      (validate-mock-called-with-expected-args function mock-config) => anything
+      (provided
+        (do-report (as-checker #(= :pass (:type %)))) => nil :times 1
+        (do-report (as-checker #(= :fail (:type %)))) => nil :times 1)))
+
+  (fact
+    "validate-mock-called-with-expected-args does nothing when optional :times specified"
+    (let [function 'func
+          mock-config {:mock-config {[] {:result ..foo.. :times :optional}},
+                       :calls       {[] 7}}]
+      (validate-mock-called-with-expected-args function mock-config) => anything
+      (provided
+        (do-report anything) => nil :times 0)))
+
+  (fact
     "validate-no-unexpected-calls true when no unexpected calls"
     (let [function 'func
           mock-config {:mock-config

--- a/test/smidje/clj/parser/parser_test.clj
+++ b/test/smidje/clj/parser/parser_test.clj
@@ -63,9 +63,13 @@
 (m/fact "adjust-range"
         (adjust-range '((+ 1 1) => 2 :times 1 :except 3)) m/=> '((+ 1 1) => 2 :times 1 :except 3)
         (adjust-range '((+ 1 1) => 2 :times (range) :except 3)) m/=> '((+ 1 1) => 2 :times :optional :except 3)
-        (adjust-range '((+ 1 1) => 2 :times (range 3) :except 3)) m/=> '((+ 1 1) => 2 :times {:range [0 3]} :except 3)
+        (adjust-range '((+ 1 1) => 2 :times (range 3) :except 3)) m/=> '((+ 1 1) => 2 :times {:range [1 3]} :except 3)
         (adjust-range '((+ 1 1) => 2 :times (range 2 10) :except 3)) m/=> '((+ 1 1) => 2 :times {:range [2 10]} :except 3)
-        (adjust-range '((+ 1 1) => 2 :times (range 1 2 3))) m/=> (m/throws RuntimeException #"more than two arguments"))
+        (adjust-range '((+ 1 1) => 2 :times (range 1 2 3))) m/=> (m/throws RuntimeException #"more than two arguments")
+        (adjust-range '((+ 1 1) => 2 :times (range -1 3))) m/=> (m/throws RuntimeException #"-1 must be greater than 0")
+        (adjust-range '((+ 1 1) => 2 :times (range 1 -3))) m/=> (m/throws RuntimeException #"-3 must be greater than 0")
+        (adjust-range '((+ 1 1) => 2 :times (range 3 1))) m/=> (m/throws RuntimeException #"3 must be less than or equal to 1")
+        (adjust-range '((+ 1 1) => 2 :times (range -1))) m/=> (m/throws RuntimeException #"must be greater than 0"))
 
 (m/fact "build-provided-map"
         (#'smidje.parser.parser/build-provided-map simple-addition-fact) => {:mock-function '+

--- a/test/smidje/clj/parser/parser_test.clj
+++ b/test/smidje/clj/parser/parser_test.clj
@@ -60,6 +60,13 @@
                                                                                       ((/ 4 2) => 2)
                                                                                      ((* 2 3) => 6 :times 2 :except 3)})
 
+(m/fact "adjust-range"
+        (adjust-range '((+ 1 1) => 2 :times 1 :except 3)) m/=> '((+ 1 1) => 2 :times 1 :except 3)
+        (adjust-range '((+ 1 1) => 2 :times (range) :except 3)) m/=> '((+ 1 1) => 2 :times :optional :except 3)
+        (adjust-range '((+ 1 1) => 2 :times (range 3) :except 3)) m/=> '((+ 1 1) => 2 :times {:range [0 3]} :except 3)
+        (adjust-range '((+ 1 1) => 2 :times (range 2 10) :except 3)) m/=> '((+ 1 1) => 2 :times {:range [2 10]} :except 3)
+        (adjust-range '((+ 1 1) => 2 :times (range 1 2 3))) m/=> (m/throws RuntimeException #"more than two arguments"))
+
 (m/fact "build-provided-map"
         (#'smidje.parser.parser/build-provided-map simple-addition-fact) => {:mock-function '+
                                                                       :paramaters '(1 1)

--- a/test/smidje/clj/parser/parser_test.clj
+++ b/test/smidje/clj/parser/parser_test.clj
@@ -53,9 +53,9 @@
                 '((c 4) => ..b->c02..)}
             (m/provided (gensym "a->b") m/=> 'a->b01 (gensym "b->c") m/=> 'b->c02))
 
-(m/fact "seperate-provided-forms"
-        (#'smidje.parser.parser/seperate-provided-forms simple-addition-fact) => [simple-addition-fact]
-        (set  (#'smidje.parser.parser/seperate-provided-forms
+(m/fact "separate-provided-forms"
+        (#'smidje.parser.parser/separate-provided-forms simple-addition-fact) => [simple-addition-fact]
+        (set  (#'smidje.parser.parser/separate-provided-forms
                '((+ 1 1) => 2 :times 1 (* 2 3) => 6 :times 2 :except 3 (/ 4 2) => 2))) => '#{((+ 1 1) => 2 :times 1)
                                                                                       ((/ 4 2) => 2)
                                                                                      ((* 2 3) => 6 :times 2 :except 3)})

--- a/test/smidje/cljs/macro_test.cljs
+++ b/test/smidje/cljs/macro_test.cljs
@@ -12,6 +12,13 @@
 (defn foo []
   (+ (bar) (thing 1)))
 
+(defn two-bars []
+  (+ (bar) (bar)))
+
+(defn n-bars [times-called]
+  (dotimes [n times-called]
+    (bar)))
+
 (fact "multi-provided"
       (foo) => 2
       (provided
@@ -66,6 +73,20 @@
   (thing 1) =not=> ..result..
   (provided
     (thing 1) => ..badresult..))
+
+(fact
+  "times checking"
+  (two-bars) => 4
+  (provided
+    (bar) => 2 :times 2
+    (foo) => ..whatever.. :times 0
+    (thing "foo") => ..no1cur.. :times (range)))
+
+(fact
+  "more times checking"
+  (n-bars 5) => nil?
+  (provided
+    (bar) => 2 :times (range 5)))
 
 (fact
   "expects exception when thrown by provided"


### PR DESCRIPTION
This adjusts the parsed provided map so that it has metadata for :times, specifically for defined (range) results. The existing metadata looks like:

```
(parse-provided
  '((foo "bar") => ..fb..
     (provided
       (bar "foo") => 1 :times 1)))
=> {:provided ({:mock-function bar, :return {["foo"] {:arrow :=>, :times 1, :result 1}}})}
```

Now, if a range is found, we get:

```
(parse-provided '((foo "bar") => ..fb.. (provided (bar "foo") => 1 :times (range))))
=> {:provided ({:mock-function bar, :return {["foo"] {:arrow :=>, :times :optional, :result 1}}})}
(parse-provided '((foo "bar") => ..fb.. (provided (bar "foo") => 1 :times (range 3))))
=> {:provided ({:mock-function bar, :return {["foo"] {:arrow :=>, :times {:range [0 3]}, :result 1}}})}
(parse-provided '((foo "bar") => ..fb.. (provided (bar "foo") => 1 :times (range 3 10))))
=> {:provided ({:mock-function bar, :return {["foo"] {:arrow :=>, :times {:range [3 10]}, :result 1}}})}
```